### PR TITLE
Add ScyllaDB keyspace configuration options

### DIFF
--- a/component/scylladbc/scylladbc.go
+++ b/component/scylladbc/scylladbc.go
@@ -107,16 +107,16 @@ func (s *scyllaDbComponent) Activate(ctx sctx.ServiceContext) error {
 	// Log successful activation
 	log.Printf("ScyllaDB component %s activated successfully", s.id)
 
-	// Create the keyspace if it does not exist
-	if s.config.ks != "" {
-		createKeyspaceQuery := fmt.Sprintf(`
-			CREATE KEYSPACE IF NOT EXISTS %s
-			WITH REPLICATION = {'class': '%s', 'replication_factor': %d}
-		`, s.config.ks, s.config.ksClass, s.config.ksReplicationFactor)
-		if err := s.session.Query(createKeyspaceQuery).Exec(); err != nil {
-			return fmt.Errorf("failed to create keyspace: %w", err)
-		}
-	}
+	// // Create the keyspace if it does not exist
+	// if s.config.ks != "" {
+	// 	createKeyspaceQuery := fmt.Sprintf(`
+	// 		CREATE KEYSPACE IF NOT EXISTS %s
+	// 		WITH REPLICATION = {'class': '%s', 'replication_factor': %d}
+	// 	`, s.config.ks, s.config.ksClass, s.config.ksReplicationFactor)
+	// 	if err := s.session.Query(createKeyspaceQuery).Exec(); err != nil {
+	// 		return fmt.Errorf("failed to create keyspace: %w", err)
+	// 	}
+	// }
 
 	return nil
 }

--- a/examples/scylladbcomp/.env.example
+++ b/examples/scylladbcomp/.env.example
@@ -4,14 +4,20 @@ APP_ENV="dev"
 # Timeout for establishing a connection to ScyllaDB, e.g. 10s (-scylladb-connect-timeout)
 SCYLLADB_CONNECT_TIMEOUT=10s
 
-# Comma-separated list of ScyllaDB hosts (e.g. localhost:9042,localhost:9043,localhost:9044) (-scylladb-hosts)
+# List of ScyllaDB hosts, not empty (e.g. localhost:9042,localhost:9043,localhost:9044) (-scylladb-hosts)
 SCYLLADB_HOSTS="localhost:9042,localhost:9043,localhost:9044"
 
-# ScyllaDB keyspace to use (-scylladb-keyspace)
+# ScyllaDB keyspace to use, not empty (e.g. catalog, admin, etc.) (-scylladb-keyspace)
 SCYLLADB_KEYSPACE=
 
 # ScyllaDB keyspace replication class (e.g. SimpleStrategy, NetworkTopologyStrategy) (-scylladb-keyspace-class)
 SCYLLADB_KEYSPACE_CLASS="NetworkTopologyStrategy"
+
+# Disable initial host lookup for ScyllaDB keyspace (-scylladb-keyspace-disable-initial-host-lookup)
+SCYLLADB_KEYSPACE_DISABLE_INITIAL_HOST_LOOKUP=true
+
+# Number of connections to use for ScyllaDB keyspace (-scylladb-keyspace-num-conns)
+SCYLLADB_KEYSPACE_NUM_CONNS=10
 
 # ScyllaDB keyspace replication factor (e.g. 1 for SimpleStrategy) (-scylladb-keyspace-replication-factor)
 SCYLLADB_KEYSPACE_REPLICATION_FACTOR=1


### PR DESCRIPTION
Add configuration options for ScyllaDB keyspace, including the ability to disable initial host lookup and specify the number of connections. Comment out the keyspace creation logic during activation.